### PR TITLE
Apply a typing update to align with Redux 4+.

### DIFF
--- a/src/redux.ts
+++ b/src/redux.ts
@@ -4,4 +4,4 @@ export interface Action<Type extends string> {
 
 export type AnyAction = Action<string>;
 
-export type Reducer<S, A extends AnyAction = AnyAction> = (state: S, action: A) => S;
+export type Reducer<S = any, A extends AnyAction = AnyAction> = (state: S | undefined, action: A) => S;


### PR DESCRIPTION
This will be a breaking change.

redux-compose is being used in the new onboarding frontend, and it could be brought into internal-dashboard to replace the existing use of `util/redux` or the module from frontend.